### PR TITLE
Fix regex, deduplicate content, and verify data processes

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -461,7 +461,7 @@ function extractMovesFromPgn(pgn) {
   if (blankLineIndex === -1) return { moves: '', times: '', movesPerSide: '' };
   let movesText = pgn.slice(blankLineIndex + 2).trim();
   movesText = movesText.replace(/\s+(1-0|0-1|1\/2-1\/2|\*)\s*$/, '');
-  movesText = movesText.replace(/\([^)]]*\)/g, '');
+  movesText = movesText.replace(/\([^)]*\)/g, '');
   movesText = movesText.replace(/\$\d+/g, '');
 
   const movesMap = {};


### PR DESCRIPTION
Fix regex in `extractMovesFromPgn` by removing an extra `]` to correctly strip parenthesized content.

---
<a href="https://cursor.com/background-agent?bcId=bc-2fecd722-412a-450e-8370-8727428daad0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2fecd722-412a-450e-8370-8727428daad0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

