### PR TITLE
Check for fetched games

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -433,6 +433,29 @@ function parsePgnTimezone(tags) {
   return '';
 }
 
+function extractPgnTags(pgn) {
+  const tags = {};
+  if (!pgn) return tags;
+  try {
+    // Only parse header section (before first blank line)
+    const headerEnd = pgn.indexOf('\n\n');
+    const headerText = headerEnd === -1 ? pgn : pgn.slice(0, headerEnd);
+    const re = /^\s*\[([A-Za-z0-9_]+)\s+"([^"]*)"\s*\]\s*$/gm;
+    let m;
+    while ((m = re.exec(headerText)) !== null) {
+      const key = m[1];
+      const val = m[2];
+      tags[key] = val;
+    }
+    // Normalize a few common aliases if present in non-standard casing
+    if (tags.ECOURL && !tags.ECOUrl) tags.ECOUrl = tags.ECOURL;
+    if (tags.Timezone && !tags.TimeZone) tags.TimeZone = tags.Timezone;
+  } catch (e) {
+    // Return best-effort tags on parse errors
+  }
+  return tags;
+}
+
 function computeOffsetHoursFromTz(date, tz) {
   try {
     const z = Utilities.formatDate(date, tz, 'Z'); // +0530 or -0700


### PR DESCRIPTION
Add `extractPgnTags` function to parse PGN header tags, resolving a 'not defined' error when `gameToRow` attempts to use it.

---
<a href="https://cursor.com/background-agent?bcId=bc-7babfbdc-9065-4c10-97f0-deebca51d364">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7babfbdc-9065-4c10-97f0-deebca51d364">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

