### PR TITLE
Handle missing primary username error

### DIFF
--- a/apps_script/calculated.gs
+++ b/apps_script/calculated.gs
@@ -9,8 +9,29 @@ const CALC_SETTINGS = {
 };
 
 function setPrimaryUsername(username) {
-  if (!username) throw new Error('Username required');
-  PropertiesService.getDocumentProperties().setProperty(CALC_SETTINGS.userPropertyKey, String(username));
+  let name = String(username || '').trim();
+  if (!name) {
+    try {
+      const ss = getSpreadsheet_();
+      const cfgName = (typeof SHEET_NAMES === 'object' && SHEET_NAMES.CONFIG) ? SHEET_NAMES.CONFIG : 'Config';
+      const configSheet = ss.getSheetByName(cfgName);
+      if (configSheet && typeof readConfig === 'function') {
+        const cfg = readConfig(configSheet);
+        const fromConfig = String((cfg && cfg.username) || '').trim();
+        if (fromConfig) name = fromConfig;
+      }
+    } catch (e) {}
+  }
+  if (!name) {
+    try {
+      const email = Session.getActiveUser && Session.getActiveUser();
+      const addr = email && typeof email.getEmail === 'function' ? email.getEmail() : '';
+      const local = addr ? String(addr).split('@')[0] : '';
+      if (local) name = local;
+    } catch (e) {}
+  }
+  if (!name) throw new Error('Username required. Pass setPrimaryUsername("yourname") or set Config → username.');
+  PropertiesService.getDocumentProperties().setProperty(CALC_SETTINGS.userPropertyKey, String(name));
 }
 
 function getPrimaryUsername_() {


### PR DESCRIPTION
Make `setPrimaryUsername` more robust by deriving the username from `Config` or user email if not explicitly provided.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c334e37-31a0-4192-9c87-966259476876">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c334e37-31a0-4192-9c87-966259476876">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

